### PR TITLE
Removing IterableSDK

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,21 +7,13 @@ let package = Package(
     products: [
         .library(
             name: "Intercom",
-            targets: ["Intercom"]),
-        .library(
-            name: "IterableSDK",
-            targets: ["IterableSDK"]),
+            targets: ["Intercom"])
     ],
     targets: [
         .binaryTarget(
             name: "Intercom",
             url: "https://github.com/intercom/intercom-ios/releases/download/12.2.0/Intercom.xcframework.zip",
             checksum: "3b0977c71c8ac9eab3ce315b4076cf3b905635d06d863d3c057a60e13de0782a"
-        ),
-        .binaryTarget(
-            name: "IterableSDK",
-            url: "https://github.com/Iterable/swift-sdk/releases/download/6.3.2/IterableSDK.xcframework.zip",
-            checksum: "d02f37b40783569612d5e82f8da94acfca1e81d97a176dca866a86b8886560b3"
-        ),
+        )
     ]
 )


### PR DESCRIPTION
The iOS repo does not use Iterable as a Swift Package currently, this version of Iterable exists as a Cocoapod already.