### PR TITLE
MXM - Update Intercom version to 12.2.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Intercom",
-            url: "https://github.com/intercom/intercom-ios/releases/download/12.2.0/Intercom.xcframework.zip",
-            checksum: "3b0977c71c8ac9eab3ce315b4076cf3b905635d06d863d3c057a60e13de0782a"
+            url: "https://github.com/intercom/intercom-ios/releases/download/12.2.1/Intercom.xcframework.zip",
+            checksum: "705469f671e803e74a30e51ae00be5eade2377bac3f789cacb684cb594d0f6a6"
         )
     ]
 )


### PR DESCRIPTION
Intercom added some bug fixes that we requested in their most recent release, so I'm looking to update the dependency version for those fixes. I changed the url and checksum values to reflect version 12.2.1.